### PR TITLE
Modify the function of the same name

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -129,7 +129,7 @@ class BlynkProtocol:
         self.log('<', cmd, id, '|', *args)
         msg = struct.pack("!BHH", cmd, id, dlen) + data
         self.lastSend = gettime()
-        self._send(msg)
+        self.send(msg)
 
     def connect(self):
         if self.state != DISCONNECTED: return
@@ -220,7 +220,7 @@ class Blynk(BlynkProtocol):
         except:
             raise ValueError('Connection with the Blynk servers failed')
 
-    def _send(self, data):
+    def send(self, data):
         self.conn.send(data)
         # TODO: handle disconnect
 


### PR DESCRIPTION
Blynk has the same function `_send` as its parent class BlynkProtocol. When BlynkProtocol is ready to send data, `self.conn.send(data)` in the Blynk class cannot be called because of the same name function `_send` in the BlynkProtocol class. Therefore, the socket does not send any data, which will raise connection failure.

I noticed that in the recent commits, you modified the function name, causing the function to have the same name issue.