### PR TITLE
Fix issue #27

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -4,6 +4,7 @@ _VERSION = "0.2.0"
 
 import struct
 import time
+import sys
 import os
 
 try:
@@ -46,7 +47,7 @@ print("""
    / _ )/ /_ _____  / /__
   / _  / / // / _ \\/  '_/
  /____/_/\\_, /_//_/_/\\_\\
-        /___/ for Python v""" + _VERSION + " (" + os.uname()[0] + ")\n")
+        /___/ for Python v""" + _VERSION + " (" + sys.platform + ")\n")
 
 class BlynkProtocol:
     def __init__(self, auth, heartbeat=10, buffin=1024, log=None):


### PR DESCRIPTION
os.uname() is not available on all platforms, particularily
Windows. sys.platform contains almost the same information
and is available on all platforms where I was able to test:
  - linux x86
  - linux ppc64le
  - AIX
  - Windows x86
  - ESP8266