### PR TITLE
Add digital write direct mapping function for ESP8266/ESP32

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -201,6 +201,10 @@ class BlynkProtocol:
                     elif args[0] == 'vr':
                         self.emit("readV"+args[1])
                         self.emit("readV*", args[1])
+                    elif args[0] == 'dw':
+                        if os.uname()[0][0:3] == 'esp': # ESP8266/32
+                            p = machine.Pin(int(args[1]), machine.Pin.OUT)
+                            p.value(int(args[2]))
                 elif cmd == MSG_INTERNAL:
                     self.emit("int_"+args[1], args[2:])
                 else:


### PR DESCRIPTION
Add digital write direct mapping function for ESP8266/ESP32 so that you can set widgets in Blynk to send 0/1 to phisical pins without using virtual pins.