### PR TITLE
Fixed socket disconnecting about every 2 minutes

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -256,6 +256,9 @@ class Blynk(BlynkProtocol):
             #print('>', data)
         except KeyboardInterrupt:
             raise
+        except socket.timeout:
+            # No data received, call process to send ping messages when needed
+            pass
         except: # TODO: handle disconnect
             return
         self.process(data)


### PR DESCRIPTION
When calling blynk.run(), if no data is received from the server for a while, we would never process the ping messages (heartbeat) which would cause the socket to drop after about 2 minutes.

Calling process() on socket.timeout exceptions will send the heartbeat at the configured frequency and keep the socket connected.