### PR TITLE
Added support for servers with IPv6 addresses.

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -222,8 +222,19 @@ class Blynk(BlynkProtocol):
 
     def connect(self):
         print('Connecting to %s:%d...' % (self.server, self.port))
-        s = socket.socket()
-        s.connect(socket.getaddrinfo(self.server, self.port)[0][-1])
+        # Lookup the host with a filter on the results set.
+        hostinfo = socket.getaddrinfo(self.server, self.port,
+                                      type=socket.SOCK_STREAM,
+                                      proto=socket.IPPROTO_TCP)
+        # Use the first host address entry regardless of family.
+        (family, socktype, proto, canonname, sockaddr) = hostinfo[0]
+        # An IPv6 sockaddr tuple has extra values so discard these.
+        address = sockaddr[:2]
+        # Create a TCP socket supporting IPv4 or IPv6.
+        s = socket.socket(family=family,
+                          type=socktype,
+                          proto=proto)
+        s.connect(address)
         try:
             s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         except:


### PR DESCRIPTION
The current code doesn't support Blynk servers using IPv6 addresses as the socket defaults to IPv4 (family AF_INET) and the address tuple returned by getaddrinfo() has extra values for an IPv6 host.

These changes use the family, type and proto returned by getaddrinfo() and remove the extra values in the address tuple before opening the socket.

The new code also filters the type and proto in the call to getaddrinfo() so that fewer tuples are returned.  It still uses only the first element in the list.

Tested on Fedora Linux and Python 3.11.3.
