### PR TITLE
Fix SSL context creation for MicroPython v1.23.0

### DIFF
--- a/BlynkLib.py
+++ b/BlynkLib.py
@@ -236,7 +236,7 @@ class Blynk(BlynkProtocol):
                 ssl_context = ussl
             except ImportError:
                 import ssl
-                ssl_context = ssl.create_default_context()
+                ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             self.conn = ssl_context.wrap_socket(s, server_hostname=self.server)
         try:
             self.conn.settimeout(SOCK_TIMEOUT)


### PR DESCRIPTION
Starting with MicroPython v1.23.0, the `ussl` module is no longer provided and only the [`ssl` module](https://docs.micropython.org/en/v1.23.0/library/ssl.html) is available (at least on the rp2 port).

Therefore, [l.235](https://github.com/vshymanskyy/blynk-library-python/blob/f84633c5124b84eaa4ca2f7085737099969c1423/BlynkLib.py#L235) in BlynkLib.py falls back to [l.238](https://github.com/vshymanskyy/blynk-library-python/blob/f84633c5124b84eaa4ca2f7085737099969c1423/BlynkLib.py#L238) and `AttributeError` is raised.

```
MicroPython v1.23.0 on 2024-06-02; Raspberry Pi Pico W with RP2040

Type "help()" for more information.

>>> import ussl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: no module named 'ussl'
>>> import ssl
>>> dir(ssl)
['__class__', '__name__', 'CERT_NONE', 'CERT_OPTIONAL', 'CERT_REQUIRED', 'MBEDTLS_VERSION', 'PROTOCOL_TLS_CLIENT', 'PROTOCOL_TLS_SERVER', 'SSLContext', '__dict__', '__file__', 'tls', 'wrap_socket', '__version__']
>>> ssl.create_default_context()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'create_default_context'
```

Instead of `ssl.create_default_context()`, we can use `ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)` to avoid the problem.